### PR TITLE
feat: add header case

### DIFF
--- a/cmd/tagliatelle/tagliatelle.go
+++ b/cmd/tagliatelle/tagliatelle.go
@@ -8,11 +8,12 @@ import (
 func main() {
 	cfg := tagliatelle.Config{
 		Rules: map[string]string{
-			"json": "camel",
-			"yaml": "camel",
-			"xml":  "camel",
-			"bson": "camel",
-			"avro": "snake",
+			"json":   "camel",
+			"yaml":   "camel",
+			"xml":    "camel",
+			"bson":   "camel",
+			"avro":   "snake",
+			"header": "header",
 		},
 		UseFieldName: true,
 	}

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Supported string casing:
 - `lower`
 
 | Source         | Camel Case     | Go Camel Case  |
-| -------------- | -------------- | -------------- |
+|----------------|----------------|----------------|
 | GooID          | gooId          | gooID          |
 | HTTPStatusCode | httpStatusCode | httpStatusCode |
 | FooBAR         | fooBar         | fooBar         |
@@ -33,7 +33,7 @@ Supported string casing:
 | UneTête        | uneTête        | uneTête        |
 
 | Source         | Pascal Case    | Go Pascal Case |
-| -------------- | -------------- | -------------- |
+|----------------|----------------|----------------|
 | GooID          | GooId          | GooID          |
 | HTTPStatusCode | HttpStatusCode | HTTPStatusCode |
 | FooBAR         | FooBar         | FooBar         |
@@ -46,7 +46,7 @@ Supported string casing:
 | UneTête        | UneTête        | UneTête        |
 
 | Source         | Snake Case       | Go Snake Case    |
-| -------------- | ---------------- | ---------------- |
+|----------------|------------------|------------------|
 | GooID          | goo_id           | goo_ID           |
 | HTTPStatusCode | http_status_code | HTTP_status_code |
 | FooBAR         | foo_bar          | foo_bar          |
@@ -58,18 +58,31 @@ Supported string casing:
 | NameJSON       | name_json        | name_JSON        |
 | UneTête        | une_tête         | une_tête         |
 
-| Source         | Kebab Case       | Go KebabCase     | Header Case      |
-| -------------- | ---------------- | ---------------- | ---------------- |
-| GooID          | goo-id           | goo-ID           | Goo-Id           |
-| HTTPStatusCode | http-status-code | HTTP-status-code | Http-Status-Code |
-| FooBAR         | foo-bar          | foo-bar          | Foo-Bar          |
-| URL            | url              | URL              | Url              |
-| ID             | id               | ID               | Id               |
-| hostIP         | host-ip          | host-IP          | Host-Ip          |
-| JSON           | json             | JSON             | Json             |
-| JSONName       | json-name        | JSON-name        | Json-Name        |
-| NameJSON       | name-json        | name-JSON        | Name-Json        |
-| UneTête        | une-tête         | une-tête         | Une-Tête         |
+| Source         | Kebab Case       | Go KebabCase     |
+|----------------|------------------|------------------|
+| GooID          | goo-id           | goo-ID           |
+| HTTPStatusCode | http-status-code | HTTP-status-code |
+| FooBAR         | foo-bar          | foo-bar          |
+| URL            | url              | URL              |
+| ID             | id               | ID               |
+| hostIP         | host-ip          | host-IP          |
+| JSON           | json             | JSON             |
+| JSONName       | json-name        | JSON-name        |
+| NameJSON       | name-json        | name-JSON        |
+| UneTête        | une-tête         | une-tête         |
+
+| Source         | Header Case      |
+|----------------|------------------|
+| GooID          | Goo-Id           |
+| HTTPStatusCode | Http-Status-Code |
+| FooBAR         | Foo-Bar          |
+| URL            | Url              |
+| ID             | Id               |
+| hostIP         | Host-Ip          |
+| JSON           | Json             |
+| JSONName       | Json-Name        |
+| NameJSON       | Name-Json        |
+| UneTête        | Une-Tête         |
 
 ## Examples
 
@@ -131,7 +144,7 @@ Here are the default rules for the well known and used tags, when using tagliate
 
 - `json`: `camel`
 - `yaml`: `camel`
-- `xml` : `camel`
+- `xml`: `camel`
 - `bson`: `camel`
 - `avro`: `snake`
 

--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,7 @@ Here are the default rules for the well known and used tags, when using tagliate
 - `xml`: `camel`
 - `bson`: `camel`
 - `avro`: `snake`
+- `header`: `header`
 
 ### Custom Rules
 

--- a/readme.md
+++ b/readme.md
@@ -15,11 +15,12 @@ Supported string casing:
 - `goPascal` Respects [Go's common initialisms](https://github.com/golang/lint/blob/83fdc39ff7b56453e3793356bcff3070b9b96445/lint.go#L770-L809) (e.g. HttpResponse -> HTTPResponse).
 - `goKebab` Respects [Go's common initialisms](https://github.com/golang/lint/blob/83fdc39ff7b56453e3793356bcff3070b9b96445/lint.go#L770-L809) (e.g. HttpResponse -> HTTPResponse).
 - `goSnake` Respects [Go's common initialisms](https://github.com/golang/lint/blob/83fdc39ff7b56453e3793356bcff3070b9b96445/lint.go#L770-L809) (e.g. HttpResponse -> HTTPResponse).
+- `header`
 - `upper`
 - `lower`
 
 | Source         | Camel Case     | Go Camel Case  |
-|----------------|----------------|----------------|
+| -------------- | -------------- | -------------- |
 | GooID          | gooId          | gooID          |
 | HTTPStatusCode | httpStatusCode | httpStatusCode |
 | FooBAR         | fooBar         | fooBar         |
@@ -32,7 +33,7 @@ Supported string casing:
 | UneTête        | uneTête        | uneTête        |
 
 | Source         | Pascal Case    | Go Pascal Case |
-|----------------|----------------|----------------|
+| -------------- | -------------- | -------------- |
 | GooID          | GooId          | GooID          |
 | HTTPStatusCode | HttpStatusCode | HTTPStatusCode |
 | FooBAR         | FooBar         | FooBar         |
@@ -45,7 +46,7 @@ Supported string casing:
 | UneTête        | UneTête        | UneTête        |
 
 | Source         | Snake Case       | Go Snake Case    |
-|----------------|------------------|------------------|
+| -------------- | ---------------- | ---------------- |
 | GooID          | goo_id           | goo_ID           |
 | HTTPStatusCode | http_status_code | HTTP_status_code |
 | FooBAR         | foo_bar          | foo_bar          |
@@ -57,18 +58,18 @@ Supported string casing:
 | NameJSON       | name_json        | name_JSON        |
 | UneTête        | une_tête         | une_tête         |
 
-| Source         | Kebab Case       | Go KebabCase     |
-|----------------|------------------|------------------|
-| GooID          | goo-id           | goo-ID           |
-| HTTPStatusCode | http-status-code | HTTP-status-code |
-| FooBAR         | foo-bar          | foo-bar          |
-| URL            | url              | URL              |
-| ID             | id               | ID               |
-| hostIP         | host-ip          | host-IP          |
-| JSON           | json             | JSON             |
-| JSONName       | json-name        | JSON-name        |
-| NameJSON       | name-json        | name-JSON        |
-| UneTête        | une-tête         | une-tête         |
+| Source         | Kebab Case       | Go KebabCase     | Header Case      |
+| -------------- | ---------------- | ---------------- | ---------------- |
+| GooID          | goo-id           | goo-ID           | Goo-Id           |
+| HTTPStatusCode | http-status-code | HTTP-status-code | Http-Status-Code |
+| FooBAR         | foo-bar          | foo-bar          | Foo-Bar          |
+| URL            | url              | URL              | Url              |
+| ID             | id               | ID               | Id               |
+| hostIP         | host-ip          | host-IP          | Host-Ip          |
+| JSON           | json             | JSON             | Json             |
+| JSONName       | json-name        | JSON-name        | Json-Name        |
+| NameJSON       | name-json        | name-JSON        | Name-Json        |
+| UneTête        | une-tête         | une-tête         | Une-Tête         |
 
 ## Examples
 
@@ -130,7 +131,7 @@ Here are the default rules for the well known and used tags, when using tagliate
 
 - `json`: `camel`
 - `yaml`: `camel`
-- `xml`:  `camel`
+- `xml` : `camel`
 - `bson`: `camel`
 - `avro`: `snake`
 

--- a/tagliatelle.go
+++ b/tagliatelle.go
@@ -201,7 +201,7 @@ func getConverter(c string) (func(s string) string, error) {
 	case "goSnake":
 		return strcase.ToGoSnake, nil
 	case "header":
-		return func(s string) string { return strcase.ToCase(s, strcase.TitleCase, '-') }, nil
+		return toHeader, nil
 	case "upper":
 		return strings.ToUpper, nil
 	case "lower":
@@ -209,4 +209,8 @@ func getConverter(c string) (func(s string) string, error) {
 	default:
 		return nil, fmt.Errorf("unsupported case: %s", c)
 	}
+}
+
+func toHeader(s string) string {
+	return strcase.ToCase(s, strcase.TitleCase, '-')
 }

--- a/tagliatelle.go
+++ b/tagliatelle.go
@@ -200,6 +200,8 @@ func getConverter(c string) (func(s string) string, error) {
 		return strcase.ToGoKebab, nil
 	case "goSnake":
 		return strcase.ToGoSnake, nil
+	case "header":
+		return func(s string) string { return strcase.ToCase(s, strcase.TitleCase, '-') }, nil
 	case "upper":
 		return strings.ToUpper, nil
 	case "lower":

--- a/tagliatelle_test.go
+++ b/tagliatelle_test.go
@@ -18,6 +18,7 @@ func TestAnalyzer(t *testing.T) {
 			"bson":         "camel",
 			"avro":         "snake",
 			"mapstructure": "kebab",
+			"header":       "header",
 		},
 		UseFieldName: true,
 	}

--- a/testdata/src/a/sample.go
+++ b/testdata/src/a/sample.go
@@ -25,11 +25,13 @@ type Bir struct {
 }
 
 type Bur struct {
-	Name    string
-	Value   string `yaml:"Value"` // want `yaml\(camel\): got 'Value' want 'value'`
-	More    string `json:"-"`
-	Also    string `json:",omitempty"` // want `json\(camel\): got 'Also' want 'also'`
-	ReqPerS string `avro:"req_per_s"`
+	Name             string
+	Value            string `yaml:"Value"` // want `yaml\(camel\): got 'Value' want 'value'`
+	More             string `json:"-"`
+	Also             string `json:",omitempty"` // want `json\(camel\): got 'Also' want 'also'`
+	ReqPerS          string `avro:"req_per_s"`
+	HeaderValue      string `header:"Header-Value"`
+	WrongHeaderValue string `header:"Header_Value"` // want `header\(header\): got 'Header_Value' want 'Wrong-Header-Value'`
 }
 
 type Quux struct {


### PR DESCRIPTION
Adds validation for `Header-Case`.

If https://github.com/ettle/strcase/pull/9 is merged we could replace with `strcase.ToHeader`