### PR TITLE
feat: add support for env vars and UPPER_SNAKE case

### DIFF
--- a/cmd/tagliatelle/tagliatelle.go
+++ b/cmd/tagliatelle/tagliatelle.go
@@ -8,12 +8,13 @@ import (
 func main() {
 	cfg := tagliatelle.Config{
 		Rules: map[string]string{
-			"json":   "camel",
-			"yaml":   "camel",
-			"xml":    "camel",
-			"bson":   "camel",
-			"avro":   "snake",
-			"header": "header",
+			"json":      "camel",
+			"yaml":      "camel",
+			"xml":       "camel",
+			"bson":      "camel",
+			"avro":      "snake",
+			"header":    "header",
+			"envconfig": "upperSnake",
 		},
 		UseFieldName: true,
 	}

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,7 @@ Supported string casing:
 - `pascal`
 - `kebab`
 - `snake`
+- `upperSnake`
 - `goCamel` Respects [Go's common initialisms](https://github.com/golang/lint/blob/83fdc39ff7b56453e3793356bcff3070b9b96445/lint.go#L770-L809) (e.g. HttpResponse -> HTTPResponse).
 - `goPascal` Respects [Go's common initialisms](https://github.com/golang/lint/blob/83fdc39ff7b56453e3793356bcff3070b9b96445/lint.go#L770-L809) (e.g. HttpResponse -> HTTPResponse).
 - `goKebab` Respects [Go's common initialisms](https://github.com/golang/lint/blob/83fdc39ff7b56453e3793356bcff3070b9b96445/lint.go#L770-L809) (e.g. HttpResponse -> HTTPResponse).
@@ -45,18 +46,18 @@ Supported string casing:
 | NameJSON       | NameJson       | NameJSON       |
 | UneTête        | UneTête        | UneTête        |
 
-| Source         | Snake Case       | Go Snake Case    |
-|----------------|------------------|------------------|
-| GooID          | goo_id           | goo_ID           |
-| HTTPStatusCode | http_status_code | HTTP_status_code |
-| FooBAR         | foo_bar          | foo_bar          |
-| URL            | url              | URL              |
-| ID             | id               | ID               |
-| hostIP         | host_ip          | host_IP          |
-| JSON           | json             | JSON             |
-| JSONName       | json_name        | JSON_name        |
-| NameJSON       | name_json        | name_JSON        |
-| UneTête        | une_tête         | une_tête         |
+| Source         | Snake Case       | Upper Snake Case | Go Snake Case    |
+|----------------|------------------|------------------|------------------|
+| GooID          | goo_id           | GOO_ID           | goo_ID           |
+| HTTPStatusCode | http_status_code | HTTP_STATUS_CODE | HTTP_status_code |
+| FooBAR         | foo_bar          | FOO_BAR          | foo_bar          |
+| URL            | url              | URL              | URL              |
+| ID             | id               | ID               | ID               |
+| hostIP         | host_ip          | HOST_IP          | host_IP          |
+| JSON           | json             | JSON             | JSON             |
+| JSONName       | json_name        | JSON_NAME        | JSON_name        |
+| NameJSON       | name_json        | NAME_JSON        | name_JSON        |
+| UneTête        | une_tête         | UNE_TÊTE         | une_tête         |
 
 | Source         | Kebab Case       | Go KebabCase     |
 |----------------|------------------|------------------|
@@ -120,7 +121,7 @@ linters-settings:
       use-field-name: true
       rules:
         # Any struct tag type can be used.
-        # Support string case: `camel`, `pascal`, `kebab`, `snake`, `goCamel`, `goPascal`, `goKebab`, `goSnake`, `upper`, `lower`
+        # Support string case: `camel`, `pascal`, `kebab`, `snake`, `upperSnake`, `goCamel`, `goPascal`, `goKebab`, `goSnake`, `upper`, `lower`, `header`.
         json: camel
         yaml: camel
         xml: camel
@@ -148,6 +149,7 @@ Here are the default rules for the well known and used tags, when using tagliate
 - `bson`: `camel`
 - `avro`: `snake`
 - `header`: `header`
+- `envconfig`: `upperSnake`
 
 ### Custom Rules
 

--- a/tagliatelle.go
+++ b/tagliatelle.go
@@ -204,6 +204,8 @@ func getConverter(c string) (func(s string) string, error) {
 		return toHeader, nil
 	case "upper":
 		return strings.ToUpper, nil
+	case "upperSnake":
+		return strcase.ToSNAKE, nil
 	case "lower":
 		return strings.ToLower, nil
 	default:

--- a/tagliatelle_test.go
+++ b/tagliatelle_test.go
@@ -19,6 +19,7 @@ func TestAnalyzer(t *testing.T) {
 			"avro":         "snake",
 			"mapstructure": "kebab",
 			"header":       "header",
+			"envconfig":    "upperSnake",
 		},
 		UseFieldName: true,
 	}

--- a/testdata/src/a/sample.go
+++ b/testdata/src/a/sample.go
@@ -25,13 +25,15 @@ type Bir struct {
 }
 
 type Bur struct {
-	Name             string
-	Value            string `yaml:"Value"` // want `yaml\(camel\): got 'Value' want 'value'`
-	More             string `json:"-"`
-	Also             string `json:",omitempty"` // want `json\(camel\): got 'Also' want 'also'`
-	ReqPerS          string `avro:"req_per_s"`
-	HeaderValue      string `header:"Header-Value"`
-	WrongHeaderValue string `header:"Header_Value"` // want `header\(header\): got 'Header_Value' want 'Wrong-Header-Value'`
+	Name                string
+	Value               string `yaml:"Value"` // want `yaml\(camel\): got 'Value' want 'value'`
+	More                string `json:"-"`
+	Also                string `json:",omitempty"` // want `json\(camel\): got 'Also' want 'also'`
+	ReqPerS             string `avro:"req_per_s"`
+	HeaderValue         string `header:"Header-Value"`
+	WrongHeaderValue    string `header:"Header_Value"` // want `header\(header\): got 'Header_Value' want 'Wrong-Header-Value'`
+	EnvConfigValue      string `envconfig:"ENV_CONFIG_VALUE"`
+	WrongEnvConfigValue string `envconfig:"env_config_value"` // want `envconfig\(upperSnake\): got 'env_config_value' want 'WRONG_ENV_CONFIG_VALUE'`
 }
 
 type Quux struct {


### PR DESCRIPTION
This PR adds support for the `upperSnake` case (known as `ToSNAKE` in [github.com/ettle/strcase](https://github.com/ettle/strcase)). Happy to discuss/change the name of this.

The main motivation for this is to support environment variables in struct tags. For example the [github.com/kelseyhightower/envconfig](https://github.com/kelseyhightower/envconfig) package makes use of an `envconfig` tag to parse environment variables into a struct. Forcing these to be in `UPPER_SNAKE` case would be useful.