### PR TITLE
feat: add support for struct level overrides

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,16 @@ type Foo struct {
 }
 ```
 
+If for some reason you really really want to override the rules
+only for a specific struct you can add a struct-level comment:
+
+```go
+// tagliatelle: json=camel yaml=snake
+type Foo struct {
+    ID     string `json:"ID"` // must be "id"
+}
+```
+
 ## What this tool is about
 
 This tool is about validating tags according to rules you define.

--- a/tagliatelle_test.go
+++ b/tagliatelle_test.go
@@ -21,6 +21,8 @@ func TestAnalyzer(t *testing.T) {
 			"header":       "header",
 			"envconfig":    "upperSnake",
 			"env":          "upperSnake",
+			"foo":          "camel",
+			"bar":          "camel",
 		},
 		UseFieldName: true,
 	}

--- a/testdata/src/a/sample.go
+++ b/testdata/src/a/sample.go
@@ -1,5 +1,10 @@
 package a
 
+// some random comment
+// the StructLevelRule* fields are both set to "camel", but should be
+// overridden by the following comment to "snake" and "upperSnake"
+// tagliatelle: foo=snake bar=upperSnake
+// some other random comment
 type Foo struct {
 	ID     string `json:"ID"`     // want `json\(camel\): got 'ID' want 'id'`
 	UserID string `json:"UserID"` // want `json\(camel\): got 'UserID' want 'userId'`
@@ -10,6 +15,9 @@ type Foo struct {
 
 	Qiix Quux `json:",inline"`
 	Quux `json:",inline"`
+
+	StructLevelRuleFoo string `foo:"struct_level_rule_foo"`
+	StructLevelRuleBar string `bar:"struct_level_rule_bar"` // want `bar\(upperSnake\): got 'struct_level_rule_bar' want 'STRUCT_LEVEL_RULE_BAR'`
 }
 
 type Bar struct {


### PR DESCRIPTION
Hey! :)

We were looking into using this with @pd93 to lint some stuff, but unfortunatelly we have a bunch of snowflake structs that need to be different to everything else.

This is a proposal to add a struct-level comment that can override the rules for the given struct. Happy to change the comment format if there are better suggestions.

The way this is implemented is not really ideal but it should be good enough for this usecase without complicating things even more. It basically adds `astCommentGroup` to the node filter, and attempts to keep track of the rules defined before each struct, and clearing them once the struct or another comment has been processed.

The idea is taken from the way `go/doc` [deals with a similar situation](https://cs.opensource.google/go/go/+/refs/tags/go1.20.3:src/go/doc/reader.go;l=361-394) and some discussion on edge cases can be found [here](https://stackoverflow.com/a/35487263). As we only care and deal with structs, and this comment only applies on structs, I can't think there will be an issue with going forward with this implementation, but any comments on possible issues would be more than welcome.

Let me know if this is something you think would be of interest and what you think it would take to get this merged! :D

Regards,
~geoah

cc @pd93 