### PR TITLE
Add "toml" tag in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,8 +123,8 @@ linters-settings:
         # Any struct tag type can be used.
         # Support string case: `camel`, `pascal`, `kebab`, `snake`, `upperSnake`, `goCamel`, `goPascal`, `goKebab`, `goSnake`, `upper`, `lower`, `header`.
         json: camel
-        xml: camel
         yaml: camel
+        xml: camel
         toml: camel
 ```
 
@@ -173,8 +173,8 @@ linters-settings:
         # Any struct tag type can be used.
         # Support string case: `camel`, `pascal`, `kebab`, `snake`, `goCamel`, `goPascal`, `goKebab`, `goSnake`, `upper`, `lower`
         json: camel
-        xml: camel
         yaml: camel
+        xml: camel
         toml: camel
         whatever: kebab
 ```

--- a/readme.md
+++ b/readme.md
@@ -122,9 +122,10 @@ linters-settings:
       rules:
         # Any struct tag type can be used.
         # Support string case: `camel`, `pascal`, `kebab`, `snake`, `upperSnake`, `goCamel`, `goPascal`, `goKebab`, `goSnake`, `upper`, `lower`, `header`.
-        json: camel
-        yaml: camel
-        xml: camel
+        json:     camel
+        xml:      camel
+        yaml:     camel
+        toml:     camel
 ```
 
 More information here https://golangci-lint.run/usage/linters/#tagliatelle
@@ -172,7 +173,8 @@ linters-settings:
         # Any struct tag type can be used.
         # Support string case: `camel`, `pascal`, `kebab`, `snake`, `goCamel`, `goPascal`, `goKebab`, `goSnake`, `upper`, `lower`
         json:     camel
-        yaml:     camel
         xml:      camel
+        yaml:     camel
+        toml:     camel
         whatever: kebab
 ```

--- a/readme.md
+++ b/readme.md
@@ -122,10 +122,10 @@ linters-settings:
       rules:
         # Any struct tag type can be used.
         # Support string case: `camel`, `pascal`, `kebab`, `snake`, `upperSnake`, `goCamel`, `goPascal`, `goKebab`, `goSnake`, `upper`, `lower`, `header`.
-        json:     camel
-        xml:      camel
-        yaml:     camel
-        toml:     camel
+        json: camel
+        xml: camel
+        yaml: camel
+        toml: camel
 ```
 
 More information here https://golangci-lint.run/usage/linters/#tagliatelle
@@ -172,9 +172,9 @@ linters-settings:
       rules:
         # Any struct tag type can be used.
         # Support string case: `camel`, `pascal`, `kebab`, `snake`, `goCamel`, `goPascal`, `goKebab`, `goSnake`, `upper`, `lower`
-        json:     camel
-        xml:      camel
-        yaml:     camel
-        toml:     camel
+        json: camel
+        xml: camel
+        yaml: camel
+        toml: camel
         whatever: kebab
 ```


### PR DESCRIPTION
In some project guys was confused from absent `toml` in the linter readme.